### PR TITLE
Raise min WP/PHP requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
-
 All notable changes to this project will be documented in this file, formatted via [this recommendation](https://keepachangelog.com/).
+
+## [UNRELEASED] - 2022-XX-XX
+### IMPORTANT
+- Support for WordPress 5.1 has been discontinued. If you are running WordPress 5.1, you MUST upgrade WordPress before installing File Upload Types 1.3.0. Failure to do that will disable File Upload Types core functionality.
+
+### Added
+- 
+
+### Changed
+- 
+
+### Fixed
+- 
 
 ## [1.2.2] - 2021-06-17
 * Fix - PHP notices when invalid files are uploaded.

--- a/file-upload-types.php
+++ b/file-upload-types.php
@@ -15,20 +15,21 @@ defined( 'ABSPATH' ) || exit;
 // Exit if accessed directly.
 
 /**
+ * Deactivate the plugin.
+ *
+ * @since 1.0.0
+ */
+function file_upload_types_deactivate() {
+
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+}
+
+/**
  * The plugin requires PHP 5.6.0+.
  * It will self-deactivate on older PHP versions ad will notify an admin.
  */
-if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
+if ( PHP_VERSION_ID < 50600 ) {
 
-	/**
-	 * Deactivate the plugin.
-	 *
-	 * @since 1.0.0
-	 */
-	function file_upload_types_deactivate() {
-
-		deactivate_plugins( plugin_basename( __FILE__ ) );
-	}
 	add_action( 'admin_init', 'file_upload_types_deactivate' );
 
 	/**
@@ -55,6 +56,37 @@ if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
 
 	return;
 }//end if
+
+// We require WP version 5.2+ for the whole plugin to work.
+if ( version_compare( $GLOBALS['wp_version'], '5.2', '<' ) ) {
+
+	add_action( 'admin_init', 'file_upload_types_deactivate' );
+
+	/**
+	 * Display a notice after deactivation.
+	 *
+	 * @since {VERSION}
+	 */
+	function file_upload_types_deactivate_msg_old_wp() {
+
+		// Display the message to admin only.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		echo '<div class="notice notice-error"><p>';
+		echo esc_html__( 'The File Upload Types plugin has been deactivated. Your site is running an outdated version of WordPress that is no longer supported and is not compatible with the File Upload Types plugin.', 'file-upload-types' );
+		echo '</p></div>';
+
+		if ( isset( $_GET['activate'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			unset( $_GET['activate'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+	}
+	add_action( 'admin_notices', 'file_upload_types_deactivate_msg_old_wp' );
+
+	// Do not process the plugin code further.
+	return;
+}
 
 /**
  * Plugin constants.

--- a/file-upload-types.php
+++ b/file-upload-types.php
@@ -3,6 +3,8 @@
  * Plugin Name: File Upload Types
  * Description: Easily allow WordPress to accept and upload any file type extension or MIME type, including custom file types.
  * Version: 1.2.2
+ * Requires at least: 5.2
+ * Requires PHP: 5.6
  * Author: WPForms
  * Author URI: https://wpforms.com
  * Text Domain: file-upload-types

--- a/file-upload-types.php
+++ b/file-upload-types.php
@@ -11,8 +11,8 @@
  * Domain Path: /languages/
  */
 
-defined( 'ABSPATH' ) || exit;
 // Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Deactivate the plugin.
@@ -25,8 +25,8 @@ function file_upload_types_deactivate() {
 }
 
 /**
- * The plugin requires PHP 5.6.0+.
- * It will self-deactivate on older PHP versions ad will notify an admin.
+ * The plugin requires PHP version 5.6+.
+ * It will self-deactivate on older PHP versions and will notify an admin.
  */
 if ( PHP_VERSION_ID < 50600 ) {
 
@@ -48,16 +48,23 @@ if ( PHP_VERSION_ID < 50600 ) {
 		echo esc_html__( 'The File Upload Types plugin has been deactivated. Your site is running an outdated version of PHP that is no longer supported and is not compatible with the File Upload Types plugin.', 'file-upload-types' );
 		echo '</p></div>';
 
-		if ( isset( $_GET['activate'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			unset( $_GET['activate'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// In case this is on plugin activation.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['activate'] ) ) {
+			unset( $_GET['activate'] );
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 	add_action( 'admin_notices', 'file_upload_types_deactivate_msg' );
 
+	// Do not process the plugin code further.
 	return;
-}//end if
+}
 
-// We require WP version 5.2+ for the whole plugin to work.
+/**
+ * The plugin requires WP version 5.2+.
+ * It will self-deactivate on older WP versions and will notify an admin.
+ */
 if ( version_compare( $GLOBALS['wp_version'], '5.2', '<' ) ) {
 
 	add_action( 'admin_init', 'file_upload_types_deactivate' );
@@ -75,12 +82,18 @@ if ( version_compare( $GLOBALS['wp_version'], '5.2', '<' ) ) {
 		}
 
 		echo '<div class="notice notice-error"><p>';
-		echo esc_html__( 'The File Upload Types plugin has been deactivated. Your site is running an outdated version of WordPress that is no longer supported and is not compatible with the File Upload Types plugin.', 'file-upload-types' );
+		printf( /* translators: %s - WordPress version. */
+			esc_html__( 'The File Upload Types plugin has been deactivated because it requires WordPress %s or greater.', 'file-upload-types' ),
+			'5.2'
+		);
 		echo '</p></div>';
 
-		if ( isset( $_GET['activate'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			unset( $_GET['activate'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// In case this is on plugin activation.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['activate'] ) ) {
+			unset( $_GET['activate'] );
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 	add_action( 'admin_notices', 'file_upload_types_deactivate_msg_old_wp' );
 

--- a/file-upload-types.php
+++ b/file-upload-types.php
@@ -74,7 +74,7 @@ if ( version_compare( $GLOBALS['wp_version'], '5.2', '<' ) ) {
 	 *
 	 * @since {VERSION}
 	 */
-	function file_upload_types_deactivate_msg_old_wp() {
+	function file_upload_types_wp_notice() {
 
 		// Display the message to admin only.
 		if ( ! current_user_can( 'manage_options' ) ) {
@@ -95,7 +95,7 @@ if ( version_compare( $GLOBALS['wp_version'], '5.2', '<' ) ) {
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
-	add_action( 'admin_notices', 'file_upload_types_deactivate_msg_old_wp' );
+	add_action( 'admin_notices', 'file_upload_types_wp_notice' );
 
 	// Do not process the plugin code further.
 	return;

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === File Upload Types by WPForms ===
-Contributors: wpforms, smub, jaredatch, slaFFik, sanzeeb3
+Contributors: wpforms, smub, jaredatch, slaFFik, sanzeeb3, kkarpieszuk
 Tags: files, upload, file upload, mime, attachments
-Requires at least: 4.9
-Tested up to: 5.8
+Requires at least: 5.2
+Tested up to: 6.0
 Stable tag: 1.2.2
 Requires PHP: 5.6
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === File Upload Types by WPForms ===
-Contributors: wpforms, smub, jaredatch, slaFFik, sanzeeb3, kkarpieszuk
+Contributors: wpforms, smub, jaredatch, slaFFik, kkarpieszuk
 Tags: files, upload, file upload, mime, attachments
 Requires at least: 5.2
 Tested up to: 6.0


### PR DESCRIPTION
- added required versions to the plugin header
- plugin is already checking PHP version if is 5.6 or newer (very beginning of the plugin file) so I updated only the aboves

Fixes #41 