### PR TITLE
Support for WPForms Coding Standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,15 @@
   "homepage": "https://github.com/awesomemotive.com/file-upload-types",
   "type": "wordpress-plugin",
   "license": "GPL-2.0+",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/awesomemotive/wpforms-phpcs.git"
+    }
+  ],
   "require": {
     "php": ">=5.6",
-    "composer/installers": "1.7.0"
+    "composer/installers": "~1.0"
   },
   "scripts": {
     "phpcs": [
@@ -26,5 +32,15 @@
     "files": [
       "src/functions.php"
     ]
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  },
+  "require-dev": {
+    "awesomemotive/wpforms-phpcs": "^1.0",
+    "wp-coding-standards/wpcs": "^2.3"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,42 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "191e8c124bbfd105445aa61bf98c2ca6",
+    "content-hash": "0741a30fc7f6277bf253b413f50dcb4b",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.7.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "141b272484481432cda342727a427dc1e206bfa0"
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/141b272484481432cda342727a427dc1e206bfa0",
-                "reference": "141b272484481432cda342727a427dc1e206bfa0",
+                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "^4.8.36"
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
@@ -65,6 +69,7 @@
                 "Kanboard",
                 "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
                 "Mautic",
                 "Maya",
                 "OXID",
@@ -72,6 +77,7 @@
                 "Porto",
                 "RadPHP",
                 "SMF",
+                "Starbug",
                 "Thelia",
                 "Whmcs",
                 "WolfCMS",
@@ -105,13 +111,16 @@
                 "majima",
                 "mako",
                 "mediawiki",
+                "miaoxing",
                 "modulework",
                 "modx",
                 "moodle",
                 "osclass",
+                "pantheon",
                 "phpbb",
                 "piwik",
                 "ppi",
+                "processwire",
                 "puppet",
                 "pxcms",
                 "reindex",
@@ -119,17 +128,331 @@
                 "shopware",
                 "silverstripe",
                 "sydes",
+                "sylius",
                 "symfony",
+                "tastyigniter",
                 "typo3",
                 "wordpress",
                 "yawik",
                 "zend",
                 "zikula"
             ],
-            "time": "2019-08-12T15:00:31+00:00"
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-13T08:19:44+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "awesomemotive/wpforms-phpcs",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awesomemotive/wpforms-phpcs.git",
+                "reference": "bfc7766090868425a714c4a471f94252b297d8f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awesomemotive/wpforms-phpcs/zipball/bfc7766090868425a714c4a471f94252b297d8f7",
+                "reference": "bfc7766090868425a714c4a471f94252b297d8f7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "php": "5.6 - 7.4",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "squizlabs/php_codesniffer": "^3.5",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7 - 7.5"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload-dev": {
+                "psr-4": {
+                    "WPForms\\": "WPForms",
+                    "WPForms\\Tests\\Tests\\": "WPForms/Tests"
+                }
+            },
+            "scripts": {
+                "cs": [
+                    "vendor/bin/phpcs --standard=.phpcs.xml ./WPForms -s"
+                ],
+                "unit": [
+                    "vendor/bin/phpunit --configuration ./WPForms/Tests/phpunit.xml"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "WPForms Coding Standards",
+            "support": {
+                "source": "https://github.com/awesomemotive/wpforms-phpcs/tree/1.0.4",
+                "issues": "https://github.com/awesomemotive/wpforms-phpcs/issues"
+            },
+            "time": "2022-03-09T14:53:53+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-12-12T21:44:58+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
@@ -138,5 +461,6 @@
     "platform": {
         "php": ">=5.6"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/file-upload-types.php
+++ b/file-upload-types.php
@@ -105,7 +105,7 @@ if ( version_compare( $GLOBALS['wp_version'], '5.2', '<' ) ) {
  * Plugin constants.
  */
 define( 'FILE_UPLOAD_TYPES_PLUGIN_FILE', __FILE__ );
-define( 'FILE_UPLOAD_TYPES_PLUGIN_PATH', dirname( __FILE__ ) );
+define( 'FILE_UPLOAD_TYPES_PLUGIN_PATH', __DIR__ );
 define( 'FILE_UPLOAD_TYPES_VERSION', '1.2.2' );
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
-<ruleset name="CS">
+<ruleset name="File Upload Type Plugin">
 	<description>File Upload Types Coding Standards.</description>
+
+	<!-- What to scan -->
+	<file>.</file>
 
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>node_modues/*</exclude-pattern>
@@ -16,6 +19,16 @@
 		<!-- PSR4 -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+	</rule>
+
+	<!-- Rules: WPForms Coding Standards -->
+	<config name="multi_domains" value="true"/>
+	<rule ref="WPForms"/>
+
+	<rule ref="WPForms.PHP.ValidateDomain">
+		<properties>
+			<property name="file-upload-types" value="src"/>
+		</properties>
 	</rule>
 
 	<rule ref="Generic.Metrics.CyclomaticComplexity">

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,104 +1,105 @@
 <?php
 
-defined( 'ABSPATH' ) || exit;
+if ( defined( 'ABSPATH' ) ) {
 
-/**
- * Additional available file types.
- *
- * @since 1.0.0
- *
- * @return array
- */
-function fut_get_available_file_types() {
+	/**
+	 * Additional available file types.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array
+	 */
+	function fut_get_available_file_types() {
 
-	// Serve v2 for new installs, and for old installs having multiple mime types support enabled.
-	$file = ! get_option( 'file_upload_types' ) || 'enabled' === get_option( 'file_upload_types_multiple_mimes' ) ? 'file-types-list-v2' : 'file-types-list';
+		// Serve v2 for new installs, and for old installs having multiple mime types support enabled.
+		$file = ! get_option( 'file_upload_types' ) || 'enabled' === get_option( 'file_upload_types_multiple_mimes' ) ? 'file-types-list-v2' : 'file-types-list';
 
-	$mime_types_serialized = trim( file_get_contents( dirname( FILE_UPLOAD_TYPES_PLUGIN_FILE ) . '/assets/' . $file . '.json' ) ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$mime_types_serialized = trim( file_get_contents( dirname( FILE_UPLOAD_TYPES_PLUGIN_FILE ) . '/assets/' . $file . '.json' ) ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
-	return json_decode( $mime_types_serialized, true );
-}
-
-/**
- * Formats raw data of file types.
- *
- * @since 1.0.0
- *
- * @param array $file_data_raw Raw data of the file types.
- *
- * @return array
- */
-function fut_format_raw_custom_types( $file_data_raw ) {
-
-	$file_data   = array();
-	$description = isset( $file_data_raw['desc'] ) ? array_map( 'sanitize_text_field', $file_data_raw['desc'] ) : array();
-	$mime_types  = isset( $file_data_raw['mime'] ) ? array_map( 'sanitize_text_field', $file_data_raw['mime'] ) : array();
-	$extentions  = isset( $file_data_raw['ext'] ) ? array_map( 'sanitize_text_field', $file_data_raw['ext'] ) : array();
-
-	foreach ( $description as $key => $desc ) {
-		$file_data[ $key ]['desc'] = $desc;
+		return json_decode( $mime_types_serialized, true );
 	}
 
-	foreach ( $mime_types as $key => $mime_type ) {
-		$file_data[ $key ]['mime'] = strpos( $mime_type, ',' ) === false ? $mime_type : array_filter( array_map( 'trim', explode( ',', $mime_type ) ) );
-	}
+	/**
+	 * Formats raw data of file types.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $file_data_raw Raw data of the file types.
+	 *
+	 * @return array
+	 */
+	function fut_format_raw_custom_types( $file_data_raw ) {
 
-	foreach ( $extentions as $key => $extention ) {
-		$file_data[ $key ]['ext'] = '.' . strtolower( ltrim( $extention, '.' ) );
-	}
+		$file_data   = array();
+		$description = isset( $file_data_raw['desc'] ) ? array_map( 'sanitize_text_field', $file_data_raw['desc'] ) : array();
+		$mime_types  = isset( $file_data_raw['mime'] ) ? array_map( 'sanitize_text_field', $file_data_raw['mime'] ) : array();
+		$extentions  = isset( $file_data_raw['ext'] ) ? array_map( 'sanitize_text_field', $file_data_raw['ext'] ) : array();
 
-	return $file_data;
-}
-
-/**
- * Format the file types when the multiple mime types for a single extension is entered via + icon interface.
- *
- * Same extension with multiple mime types are merged and mime types are placed in an array.
- *
- * @param array $custom_types Custom file types, may contain duplicate extensions.
- *
- * @since 1.2.0
- *
- * @return array
- */
-function fut_format_multiple_file_types( $custom_types ) {
-
-	$result   = array();
-	$ext_mime = array();
-	$ext_desc = array();
-
-	foreach ( $custom_types as $types ) {
-
-		if ( ! isset( $ext_mime[ $types['ext'] ] ) ) {
-			$ext_mime[ $types['ext'] ] = $types['mime'];
-		} else {
-			$ext_mime[ $types['ext'] ] = array_merge( (array) $ext_mime[ $types['ext'] ], (array) $types['mime'] );
+		foreach ( $description as $key => $desc ) {
+			$file_data[ $key ]['desc'] = $desc;
 		}
 
-		// The last description will be used when several mimes for a single extensions are added using + in plugin admin area.
-		$ext_desc[ $types['ext'] ] = $types['desc'];
+		foreach ( $mime_types as $key => $mime_type ) {
+			$file_data[ $key ]['mime'] = strpos( $mime_type, ',' ) === false ? $mime_type : array_filter( array_map( 'trim', explode( ',', $mime_type ) ) );
+		}
+
+		foreach ( $extentions as $key => $extention ) {
+			$file_data[ $key ]['ext'] = '.' . strtolower( ltrim( $extention, '.' ) );
+		}
+
+		return $file_data;
 	}
 
-	foreach ( $ext_mime as $ext => $mime ) {
-		$result[] = array(
-			'desc' => $ext_desc[ $ext ],
-			'mime' => $mime,
-			'ext'  => $ext,
-		);
+	/**
+	 * Format the file types when the multiple mime types for a single extension is entered via + icon interface.
+	 *
+	 * Same extension with multiple mime types are merged and mime types are placed in an array.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param array $custom_types Custom file types, may contain duplicate extensions.
+	 *
+	 * @return array
+	 */
+	function fut_format_multiple_file_types( $custom_types ) {
+
+		$result   = array();
+		$ext_mime = array();
+		$ext_desc = array();
+
+		foreach ( $custom_types as $types ) {
+
+			if ( ! isset( $ext_mime[ $types['ext'] ] ) ) {
+				$ext_mime[ $types['ext'] ] = $types['mime'];
+			} else {
+				$ext_mime[ $types['ext'] ] = array_merge( (array) $ext_mime[ $types['ext'] ], (array) $types['mime'] );
+			}
+
+			// The last description will be used when several mimes for a single extensions are added using + in plugin admin area.
+			$ext_desc[ $types['ext'] ] = $types['desc'];
+		}
+
+		foreach ( $ext_mime as $ext => $mime ) {
+			$result[] = array(
+				'desc' => $ext_desc[ $ext ],
+				'mime' => $mime,
+				'ext'  => $ext,
+			);
+		}
+
+		return $result;
 	}
 
-	return $result;
+	/**
+	 * Notice about the deprecated filter, if it's in use.
+	 *
+	 * @since 1.2.0 Deprecate the filter that is no longer needed.
+	 */
+	add_action(
+		'init',
+		static function () {
+
+			apply_filters_deprecated( 'file_upload_types_strict_check', array( true ), '1.2.0', null, 'Please add multiple MIME types for the extension whereever possible!' );
+		}
+	);
 }
-
-/**
- * Notice about the deprecated filter, if it's in use.
- *
- * @since 1.2.0 Deprecate the filter that is no longer needed.
- */
-add_action(
-	'init',
-	static function() {
-
-		apply_filters_deprecated( 'file_upload_types_strict_check', array( true ), '1.2.0', null, 'Please add multiple MIME types for the extension whereever possible!' );
-	}
-);

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,105 +1,107 @@
 <?php
 
-if ( defined( 'ABSPATH' ) ) {
+defined( 'ABSPATH' ) || exit;
 
-	/**
-	 * Additional available file types.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array
-	 */
-	function fut_get_available_file_types() {
+/**
+ * Additional available file types.
+ *
+ * @since 1.0.0
+ *
+ * @return array
+ */
+function fut_get_available_file_types() {
 
-		// Serve v2 for new installs, and for old installs having multiple mime types support enabled.
-		$file = ! get_option( 'file_upload_types' ) || 'enabled' === get_option( 'file_upload_types_multiple_mimes' ) ? 'file-types-list-v2' : 'file-types-list';
+	// Serve v2 for new installs, and for old installs having multiple mime types support enabled.
+	$file = ! get_option( 'file_upload_types' ) || 'enabled' === get_option( 'file_upload_types_multiple_mimes' ) ? 'file-types-list-v2' : 'file-types-list';
 
-		$mime_types_serialized = trim( file_get_contents( dirname( FILE_UPLOAD_TYPES_PLUGIN_FILE ) . '/assets/' . $file . '.json' ) ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	$mime_types_serialized = trim( file_get_contents( dirname( FILE_UPLOAD_TYPES_PLUGIN_FILE ) . '/assets/' . $file . '.json' ) );
 
-		return json_decode( $mime_types_serialized, true );
-	}
-
-	/**
-	 * Formats raw data of file types.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $file_data_raw Raw data of the file types.
-	 *
-	 * @return array
-	 */
-	function fut_format_raw_custom_types( $file_data_raw ) {
-
-		$file_data   = array();
-		$description = isset( $file_data_raw['desc'] ) ? array_map( 'sanitize_text_field', $file_data_raw['desc'] ) : array();
-		$mime_types  = isset( $file_data_raw['mime'] ) ? array_map( 'sanitize_text_field', $file_data_raw['mime'] ) : array();
-		$extentions  = isset( $file_data_raw['ext'] ) ? array_map( 'sanitize_text_field', $file_data_raw['ext'] ) : array();
-
-		foreach ( $description as $key => $desc ) {
-			$file_data[ $key ]['desc'] = $desc;
-		}
-
-		foreach ( $mime_types as $key => $mime_type ) {
-			$file_data[ $key ]['mime'] = strpos( $mime_type, ',' ) === false ? $mime_type : array_filter( array_map( 'trim', explode( ',', $mime_type ) ) );
-		}
-
-		foreach ( $extentions as $key => $extention ) {
-			$file_data[ $key ]['ext'] = '.' . strtolower( ltrim( $extention, '.' ) );
-		}
-
-		return $file_data;
-	}
-
-	/**
-	 * Format the file types when the multiple mime types for a single extension is entered via + icon interface.
-	 *
-	 * Same extension with multiple mime types are merged and mime types are placed in an array.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @param array $custom_types Custom file types, may contain duplicate extensions.
-	 *
-	 * @return array
-	 */
-	function fut_format_multiple_file_types( $custom_types ) {
-
-		$result   = array();
-		$ext_mime = array();
-		$ext_desc = array();
-
-		foreach ( $custom_types as $types ) {
-
-			if ( ! isset( $ext_mime[ $types['ext'] ] ) ) {
-				$ext_mime[ $types['ext'] ] = $types['mime'];
-			} else {
-				$ext_mime[ $types['ext'] ] = array_merge( (array) $ext_mime[ $types['ext'] ], (array) $types['mime'] );
-			}
-
-			// The last description will be used when several mimes for a single extensions are added using + in plugin admin area.
-			$ext_desc[ $types['ext'] ] = $types['desc'];
-		}
-
-		foreach ( $ext_mime as $ext => $mime ) {
-			$result[] = array(
-				'desc' => $ext_desc[ $ext ],
-				'mime' => $mime,
-				'ext'  => $ext,
-			);
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Notice about the deprecated filter, if it's in use.
-	 *
-	 * @since 1.2.0 Deprecate the filter that is no longer needed.
-	 */
-	add_action(
-		'init',
-		static function () {
-
-			apply_filters_deprecated( 'file_upload_types_strict_check', array( true ), '1.2.0', null, 'Please add multiple MIME types for the extension whereever possible!' );
-		}
-	);
+	return json_decode( $mime_types_serialized, true );
 }
+
+/**
+ * Formats raw data of file types.
+ *
+ * @since 1.0.0
+ *
+ * @param array $file_data_raw Raw data of the file types.
+ *
+ * @return array
+ */
+function fut_format_raw_custom_types( $file_data_raw ) {
+
+	$file_data   = [];
+	$description = isset( $file_data_raw['desc'] ) ? array_map( 'sanitize_text_field', $file_data_raw['desc'] ) : [];
+	$mime_types  = isset( $file_data_raw['mime'] ) ? array_map( 'sanitize_text_field', $file_data_raw['mime'] ) : [];
+	$extensions  = isset( $file_data_raw['ext'] ) ? array_map( 'sanitize_text_field', $file_data_raw['ext'] ) : [];
+
+	foreach ( $description as $key => $desc ) {
+		$file_data[ $key ]['desc'] = $desc;
+	}
+
+	foreach ( $mime_types as $key => $mime_type ) {
+		$file_data[ $key ]['mime'] = strpos( $mime_type, ',' ) === false ? $mime_type : array_filter( array_map( 'trim', explode( ',', $mime_type ) ) );
+	}
+
+	foreach ( $extensions as $key => $extension ) {
+		$file_data[ $key ]['ext'] = '.' . strtolower( ltrim( $extension, '.' ) );
+	}
+
+	return $file_data;
+}
+
+/**
+ * Format the file types when the multiple mime types for a single extension is entered via + icon interface.
+ *
+ * Same extension with multiple mime types are merged and mime types are placed in an array.
+ *
+ * @since 1.2.0
+ *
+ * @param array $custom_types Custom file types, may contain duplicate extensions.
+ *
+ * @return array
+ */
+function fut_format_multiple_file_types( $custom_types ) {
+
+	$result   = [];
+	$ext_mime = [];
+	$ext_desc = [];
+
+	foreach ( $custom_types as $types ) {
+
+		if ( ! isset( $ext_mime[ $types['ext'] ] ) ) {
+			$ext_mime[ $types['ext'] ] = $types['mime'];
+		} else {
+			$ext_mime[ $types['ext'] ] = array_merge( (array) $ext_mime[ $types['ext'] ], (array) $types['mime'] );
+		}
+
+		// The last description will be used when several mimes for a single extensions are added using + in plugin admin area.
+		$ext_desc[ $types['ext'] ] = $types['desc'];
+	}
+
+	foreach ( $ext_mime as $ext => $mime ) {
+		$result[] = [
+			'desc' => $ext_desc[ $ext ],
+			'mime' => $mime,
+			'ext'  => $ext,
+		];
+	}
+
+	return $result;
+}
+
+/**
+ * Notice about the deprecated filter, if it's in use.
+ *
+ * @since 1.2.0
+ *
+ * @deprepated 1.2.0 Deprecate the filter that is no longer needed.
+ */
+add_action(
+	'init',
+	static function() {
+
+		// phpcs:ignore WPForms.Comments.PHPDocHooks.RequiredHookDocumentation
+		apply_filters_deprecated( 'file_upload_types_strict_check', [ true ], '1.2.0', null, 'Please add multiple MIME types for the extension whereever possible!' );
+	}
+);


### PR DESCRIPTION
- updated composer.json to remove outdated settings
- added phpcs support
- rewritten functions.php file loding process (it had exit on the beginning which made phpcs stopping during the class loading

Fixes #42 

Test steps: 
- install plugin 
- run `composer install`
- run `vendor/bin/phpcs` (it will output plenty of errors, this is expected as plugin has some technical debt)