### PR TITLE
Remove unnecessary code that loads languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file, formatted v
 - 
 
 ### Changed
-- 
+- Do not load plugin textdomain locally, since it is not needed from WP 4.6.
 
 ### Fixed
 - Microsoft Office MIME type didn't support properly.

--- a/file-upload-types.php
+++ b/file-upload-types.php
@@ -8,7 +8,7 @@
  * Author: WPForms
  * Author URI: https://wpforms.com
  * Text Domain: file-upload-types
- * Domain Path: /languages/
+ * Domain Path: languages
  */
 
 use FileUploadTypes\Plugin as PluginAlias;

--- a/file-upload-types.php
+++ b/file-upload-types.php
@@ -8,7 +8,7 @@
  * Author: WPForms
  * Author URI: https://wpforms.com
  * Text Domain: file-upload-types
- * Domain Path: languages
+ * Domain Path: /languages/
  */
 
 use FileUploadTypes\Plugin as PluginAlias;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,21 +52,10 @@ final class Plugin {
 	 */
 	private function hooks() {
 
-		add_action( 'init', [ $this, 'load_plugin_textdomain' ] );
 		add_action( 'init', [ $this, 'register_admin_area' ] );
 		add_filter( 'plugin_action_links_' . plugin_basename( FILE_UPLOAD_TYPES_PLUGIN_FILE ), [ $this, 'plugin_action_links' ], 10, 4 );
 		add_filter( 'upload_mimes', [ $this, 'allowed_types' ] );
 		add_filter( 'wp_check_filetype_and_ext', [ $this, 'real_file_type' ], 999, 5 );
-	}
-
-	/**
-	 * Load translation files.
-	 *
-	 * @since 1.0.0
-	 */
-	public function load_plugin_textdomain() {
-
-		load_plugin_textdomain( 'file-upload-types', false, plugin_basename( dirname( FILE_UPLOAD_TYPES_PLUGIN_FILE ) ) . '/languages' );
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -176,7 +176,6 @@ final class Plugin {
 		return array_replace( $mime_types, $enabled_types );
 	}
 
-	// phpcs:disable WPForms.PHP.HooksMethod.InvalidPlaceForAddingHooks
 	/**
 	 * Filters the "real" file type of the given file.
 	 *
@@ -190,7 +189,7 @@ final class Plugin {
 	 *
 	 * @return array
 	 */
-	public function real_file_type( $file_data, $file, $filename, $mimes, $real_mime ) {
+	public function real_file_type( $file_data, $file, $filename, $mimes, $real_mime ) { // phpcs:ignore WPForms.PHP.HooksMethod.InvalidPlaceForAddingHooks
 
 		$extension     = pathinfo( $filename, PATHINFO_EXTENSION );
 		$enabled_types = $this->enabled_types();
@@ -242,5 +241,4 @@ final class Plugin {
 
 		return $file_data;
 	}
-	// phpcs:enable WPForms.PHP.HooksMethod.InvalidPlaceForAddingHooks
 }


### PR DESCRIPTION
Fixes #50 

Testing steps:
- install plugin
- go to wp-admin > settings > general and change language to russian
- go to wp-admin > settings > file upload types and see if the UI is in russian
- if not, go to wp-admin/update-core.php url and at the bottom of tyhe screen click button "Update translations"
- switch language to English and then again  russian and check if the UI is in russian