### PR TITLE
FileUploadTypes\Plugin::real_file_type is not filtering single mime type

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -209,15 +209,17 @@ final class Plugin {
 		// We don't need to do anything if the file uploads normally.
 		if ( empty( $file_data['ext'] ) && empty( $file_data['type'] ) ) {
 
-			// We don't need to do anything if there's no multiple mimes for this extension.
-			if ( empty( $enabled_types[ $extension ] ) || ! is_array( $enabled_types[ $extension ] ) ) {
+			// We don't need to do anything if there's extension in enabled types.
+			if ( empty( $enabled_types[ $extension ] ) ) {
 				return $file_data;
 			}
 
-			$mimes = $enabled_types[ $extension ];
+			$mimes = (array) $enabled_types[ $extension ];
 
 			// First mime will not need this extra behaviour.
-			unset( $mimes[0] );
+			if ( count( $mimes ) > 1 ) {
+				unset( $mimes[0] );
+			}
 
 			$mimes = array_map( 'sanitize_mime_type', $mimes );
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -209,7 +209,7 @@ final class Plugin {
 		// We don't need to do anything if the file uploads normally.
 		if ( empty( $file_data['ext'] ) && empty( $file_data['type'] ) ) {
 
-			// We don't need to do anything if there's extension in enabled types.
+			// We don't need to do anything if extension is not in enabled types.
 			if ( empty( $enabled_types[ $extension ] ) ) {
 				return $file_data;
 			}


### PR DESCRIPTION
Steps to reproduce:
- register file with extension `.world` and file mime `application/json` (or `text/plain` or `application/octet-stream` see #53 why you need to test different mime types) to be able to upload it
- go to wp-admin > media > add new and try to upload .world file (example here https://drive.google.com/file/d/1Ag6xgybEBvjUxFvo37pOuDTT_sHPTBiw/view )

For now it fails because if there is no multiple mime types registered for extension `\FileUploadTypes\Plugin::real_file_type` is not performing the registration.