### PR TITLE
 SVG file couldn't be uploaded using Upload Image in Block Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file, formatted via [this recommendation](https://keepachangelog.com/).
 
-## [1.5.0] - 2024-10-21
+## [1.5.0] - 2024-10-23
 ### Fixed
 - "Add your custom file types" link did not work before clicking on "Add file types manually" link.
 - Implemented sanitizing of SVG & HTML files.
 - Added message about allowing risky file types.
+- Some file types, even enabled, were not possible to upload using the Gutenberg editor.
 
 ## [1.4.0] - 2024-07-17
 ### Changed

--- a/readme.txt
+++ b/readme.txt
@@ -82,10 +82,11 @@ Visit <a href="http://www.wpbeginner.com/?utm_source=wprepo&utm_medium=link&utm_
 
 == Changelog ==
 
-= 1.5.0 - 2024-10-21 =
+= 1.5.0 - 2024-10-23 =
 - "Add your custom file types" link did not work before clicking on "Add file types manually" link.
 - Implemented sanitizing of SVG & HTML files.
 - Added message about allowing risky file types.
+- Some file types, even enabled, were not possible to upload using the Gutenberg editor.
 
 = 1.4.0 - 2024-07-17 =
 - New functionality to define file extension and MIME type with sample file.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -782,11 +782,11 @@ class Settings {
 		$mime_type = finfo_file( $file_info, $sample['tmp_name'] );
 		$extension = pathinfo( $sample['name'], PATHINFO_EXTENSION );
 
-		$mime_types_arr = [ (string) $mime_type ];
-
 		if ( isset( $sample['type'] ) && $mime_type !== $sample['type'] ) {
 			$mime_types_arr[] = $sample['type'];
 		}
+
+		$mime_types_arr[] = (string) $mime_type;
 
 		if ( ! $mime_type || ! $extension ) {
 			wp_send_json_error(


### PR DESCRIPTION
Fixes #86 

Test steps:
1. using file sample, enable uploading svg files (wp-admin > settings > file upload types)
2. create a Gutenberg post and try to add svg image in content
3. try to upload svg directly to wp media library
4. try to upload svg image using WPForms with field File Upload Field