### PR TITLE
 Include svg into images defined with wp_get_ext_types if svg is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file, formatted via [this recommendation](https://keepachangelog.com/).
 
-## [UNRELEASED](1.6.0) - 2024-XX-XX
+## [1.6.0] (UNRELEASED) - 2024-XX-XX
 ### Added
 - Include svg into images defined with wp_get_ext_types if svg is enabled.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file, formatted via [this recommendation](https://keepachangelog.com/).
 
+## [UNRELEASED](1.6.0) - 2024-XX-XX
+### Added
+- Include svg into images defined with wp_get_ext_types if svg is enabled.
+
 ## [1.5.0] - 2024-10-23
 ### Fixed
 - "Add your custom file types" link did not work before clicking on "Add file types manually" link.

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -20,6 +20,8 @@ class Sanitizer {
 		add_action( 'wpforms_ajax_submit_before_processing', [ $this, 'before_wpforms_processing' ] );
 		add_filter( 'wp_handle_sideload_prefilter', [ $this, 'handle_upload' ] );
 		add_filter( 'wp_handle_upload_prefilter', [ $this, 'handle_upload' ] );
+
+		add_filter( 'ext2type', [ $this, 'include_svg' ] );
 	}
 
 	/**
@@ -234,5 +236,29 @@ class Sanitizer {
 		}
 
 		return $allowed;
+	}
+
+
+
+	/**
+	 * Add SVG to wp_get_ext_types results when it's enabled.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @param array $types Array of allowed file types.
+	 *
+	 * @return array
+	 */
+	public function include_svg( $types ): array {
+
+		$enabled_types = Plugin::get_instance()->enabled_types();
+
+		if ( ! isset( $enabled_types['svg'] ) ) {
+			return $types;
+		}
+
+		$types['image'][] = 'svg';
+
+		return $types;
 	}
 }

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -243,11 +243,13 @@ class Sanitizer {
 	 *
 	 * @since {VERSION}
 	 *
-	 * @param array $types Array of allowed file types.
+	 * @param array|mixed $types Array of allowed file types.
 	 *
 	 * @return array
 	 */
 	public function include_svg( $types ): array {
+
+		$types = (array) $types;
 
 		$enabled_types = Plugin::get_instance()->enabled_types();
 

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -238,8 +238,6 @@ class Sanitizer {
 		return $allowed;
 	}
 
-
-
 	/**
 	 * Add SVG to wp_get_ext_types results when it's enabled.
 	 *


### PR DESCRIPTION
Fixes #90 

Steps to reproduce:
1. allow svg files
2. install wpforms and create from with file upload field
3. preview form, upload svg image and submit
4. go to entries and display single entry 
5. make sure uploaded file has preview thumbnail displayed with actual file content
![image](https://github.com/user-attachments/assets/ceca587d-f02e-43bf-bc45-b85a1494b50c)
