### PR TITLE
 Presave fill color in uploaded svg files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file, formatted v
 ## [1.6.0] (UNRELEASED) - 2024-XX-XX
 ### Added
 - Include svg into images defined with wp_get_ext_types if svg is enabled.
+
+### Fixed
 - Fill color in uploaded svg files.
 
 ## [1.5.0] - 2024-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, formatted v
 ## [1.6.0] (UNRELEASED) - 2024-XX-XX
 ### Added
 - Include svg into images defined with wp_get_ext_types if svg is enabled.
+- Fill color in uploaded svg files.
 
 ## [1.5.0] - 2024-10-23
 ### Fixed

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -22,6 +22,7 @@ class Sanitizer {
 		add_filter( 'wp_handle_upload_prefilter', [ $this, 'handle_upload' ] );
 
 		add_filter( 'ext2type', [ $this, 'include_svg' ] );
+		add_filter( 'safe_style_css', [ $this, 'safe_style_css' ] );
 	}
 
 	/**
@@ -105,6 +106,52 @@ class Sanitizer {
 		file_put_contents( $file, $content );
 
 		return true;
+	}
+
+	/**
+	 * Add SVG to wp_get_ext_types results when it's enabled.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @param array|mixed $types Array of allowed file types.
+	 *
+	 * @return array
+	 */
+	public function include_svg( $types ): array {
+
+		$types = (array) $types;
+
+		if ( ! $this->is_svg_allowed() ) {
+			return $types;
+		}
+
+		$types['image'][] = 'svg';
+
+		return $types;
+	}
+
+	/**
+	 * Add allowed CSS properties.
+	 *
+	 * Add 'fill' to the list of allowed CSS properties if SVG is enabled.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @param array|mixed $css CSS properties.
+	 *
+	 * @return array
+	 */
+	public function safe_style_css( $css ): array {
+
+		$css = (array) $css;
+
+		if ( ! $this->is_svg_allowed() ) {
+			return $css;
+		}
+
+		$css[] = 'fill';
+
+		return $css;
 	}
 
 	/**
@@ -239,26 +286,16 @@ class Sanitizer {
 	}
 
 	/**
-	 * Add SVG to wp_get_ext_types results when it's enabled.
+	 * Check if SVG is allowed.
 	 *
 	 * @since {VERSION}
 	 *
-	 * @param array|mixed $types Array of allowed file types.
-	 *
-	 * @return array
+	 * @return bool
 	 */
-	public function include_svg( $types ): array {
-
-		$types = (array) $types;
+	private function is_svg_allowed(): bool {
 
 		$enabled_types = Plugin::get_instance()->enabled_types();
 
-		if ( ! isset( $enabled_types['svg'] ) ) {
-			return $types;
-		}
-
-		$types['image'][] = 'svg';
-
-		return $types;
+		return isset( $enabled_types['svg'] );
 	}
 }

--- a/src/SanitizerSvg.php
+++ b/src/SanitizerSvg.php
@@ -22,41 +22,41 @@ class SanitizerSvg {
 			'width', 'height', 'viewBox', 'xmlns', 'version', 'preserveAspectRatio'
 		],
 		'rect' => [
-			'x', 'y', 'width', 'height', 'rx', 'ry', 'fill', 'stroke', 'stroke-width'
+			'x', 'y', 'width', 'height', 'rx', 'ry', 'fill', 'stroke', 'stroke-width', 'style'
 		],
 		'circle' => [
-			'cx', 'cy', 'r', 'fill', 'stroke', 'stroke-width'
+			'cx', 'cy', 'r', 'fill', 'stroke', 'stroke-width', 'style'
 		],
 		'ellipse' => [
-			'cx', 'cy', 'rx', 'ry', 'fill', 'stroke', 'stroke-width'
+			'cx', 'cy', 'rx', 'ry', 'fill', 'stroke', 'stroke-width', 'style'
 		],
 		'line' => [
-			'x1', 'y1', 'x2', 'y2', 'stroke', 'stroke-width'
+			'x1', 'y1', 'x2', 'y2', 'stroke', 'stroke-width', 'style'
 		],
 		'polyline' => [
-			'points', 'fill', 'stroke', 'stroke-width'
+			'points', 'fill', 'stroke', 'stroke-width', 'style'
 		],
 		'polygon' => [
-			'points', 'fill', 'stroke', 'stroke-width'
+			'points', 'fill', 'stroke', 'stroke-width', 'style'
 		],
 		'path' => [
-			'd', 'fill', 'stroke', 'stroke-width'
+			'd', 'fill', 'stroke', 'stroke-width', 'style'
 		],
 		'text' => [
-			'x', 'y', 'font-family', 'font-size', 'fill'
+			'x', 'y', 'font-family', 'font-size', 'fill', 'style'
 		],
 		'tspan' => [
-			'x', 'y', 'dx', 'dy'
+			'x', 'y', 'dx', 'dy', 'style'
 		],
 		'g' => [
-			'transform', 'fill', 'stroke', 'stroke-width'
+			'transform', 'fill', 'stroke', 'stroke-width', 'style'
 		],
 		'defs' => [],
 		'use' => [
 			'href', 'x', 'y', 'width', 'height'
 		],
 		'image' => [
-			'href', 'x', 'y', 'width', 'height', 'preserveAspectRatio'
+			'href', 'x', 'y', 'width', 'height', 'preserveAspectRatio', 'style'
 		],
 		'linearGradient' => [
 			'id', 'x1', 'y1', 'x2', 'y2'


### PR DESCRIPTION
Fixes #92 

Steps:
- using FUT plugin enable uploading SVG files
- using WPForms create a form to upload files, set to store them in WP Media Library
- upload this file
<details>
<summary>MY SVG</summary>

![Image](https://github.com/user-attachments/assets/186abde9-3816-4430-9bcc-e5ea5d011e25)

</details>
- check wp media library if the file has preserved colors