### PR TITLE
 Misspelling of Separated as Seperated in Comma-Seperated Values

### DIFF
--- a/assets/file-types-list-v2.json
+++ b/assets/file-types-list-v2.json
@@ -549,7 +549,7 @@
     "ext": ".dae"
   },
   {
-    "desc": "Comma-Seperated Values",
+    "desc": "Comma-Separated Values",
     "mime": [
       "text/comma-separated-values",
       "text/csv",

--- a/assets/file-types-list.json
+++ b/assets/file-types-list.json
@@ -430,7 +430,7 @@
     "ext": ".dae"
   },
   {
-    "desc": "Comma-Seperated Values",
+    "desc": "Comma-Separated Values",
     "mime": "text\/csv",
     "ext": ".csv"
   },


### PR DESCRIPTION
Fixes #96 

Steps:
- add filter:
```
 add_filter( 'upload_mimes', static function ( $mimes ) {

	unset( $mimes['csv'] );

	return $mimes;
 }, 10, 1 );
 ```
- install and activate FUT plugin
- go to wp-admin > settings > fut
- search for csv file on the list and see if description is "Comma-Separated Values"


![image](https://github.com/user-attachments/assets/d9d589cf-c7ba-4e16-ae7c-6ce5326084bb)
