### PR TITLE
 transform extensions to lowercase before comparision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file, formatted v
 
 ## [1.6.0] (UNRELEASED) - 2024-XX-XX
 ### Added
-- Include svg into images defined with wp_get_ext_types if svg is enabled.
+- Include svg in images defined with wp_get_ext_types if svg is enabled.
 
 ### Fixed
 - Fill color in uploaded svg files.
+- It was unable to use file extensions in capital letters.
 
 ## [1.5.0] - 2024-10-23
 ### Fixed

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -206,7 +206,7 @@ final class Plugin {
 	public function real_file_type( $file_data, $file, $filename, $mimes, $real_mime ): array { // phpcs:ignore WPForms.PHP.HooksMethod.InvalidPlaceForAddingHooks, Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 		$file_data     = (array) $file_data;
-		$extension     = pathinfo( $filename, PATHINFO_EXTENSION );
+		$extension     = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
 		$enabled_types = $this->enabled_types();
 
 		// We don't need to do anything if the file uploads normally.


### PR DESCRIPTION
Fixes #95 

Steps to reproduce:
1. Use this file in nxt steps
[Untitled 1.FODT](https://github.com/user-attachments/files/18532416/Untitled.1.FODT)
2. go to wp-admin > settings > fut
3. drag this file into dropzone by example to define this as allowed type
4. go to wp-admin > media > upload
5. try to upload this file, should be uploaded (with lowercase extension, normal WP behaviour)
6. with wpforms create a form with file upload field
7. preview in front end
8. try to upload this .FODT file
