### PR TITLE
ci: add WordPress.org deploy and bump-tested-up-to workflows

### DIFF
--- a/.github/workflows/wordpress-org-bump-tested-up-to.yml
+++ b/.github/workflows/wordpress-org-bump-tested-up-to.yml
@@ -1,0 +1,108 @@
+name: Bump Tested up to on WordPress.org
+
+on:
+  workflow_dispatch:
+
+env:
+  SLUG: file-upload-types
+
+jobs:
+  check-user:
+    name: Check User Authorization
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check if user is authorized
+        shell: bash
+        run: |
+          ALLOWED_USERS=("dimitris-am" "cheh" "andreas-am" "jrfoell")
+          CURRENT_USER="${{ github.actor }}"
+          AUTHORIZED=false
+
+          for user in "${ALLOWED_USERS[@]}"; do
+            if [[ "$user" == "$CURRENT_USER" ]]; then
+              AUTHORIZED=true
+              break
+            fi
+          done
+
+          if [[ "$AUTHORIZED" != "true" ]]; then
+            echo "Error: User $CURRENT_USER is not authorized to run this workflow"
+            exit 1
+          fi
+
+  bump-tested-up-to:
+    name: Bump "Tested up to" version
+    runs-on: ubuntu-24.04
+    needs: check-user
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download WordPress.org readme
+        run: |
+          # Download the current readme.txt from WordPress.org.
+          if ! curl -sSL --retry 3 --retry-delay 5 --retry-all-errors --fail -o /tmp/wp-org-readme.txt "https://plugins.svn.wordpress.org/${{ env.SLUG }}/trunk/readme.txt"; then
+            echo "::error::Could not fetch readme.txt from WordPress.org for ${{ env.SLUG }}"
+            exit 1
+          fi
+
+      - name: Extract local "Tested up to" version
+        id: extract-tested-up-to
+        run: |
+          LOCAL_TESTED_UP_TO=$(grep -E "^Tested up to:" "./readme.txt" | awk -F ': +' '{print $2}')
+          if [ -z "$LOCAL_TESTED_UP_TO" ]; then
+            echo "::error::Unable to parse local Tested up to version from readme.txt"
+            exit 1
+          fi
+          echo "version=$LOCAL_TESTED_UP_TO" >> "$GITHUB_OUTPUT"
+
+      - name: Extract "Tested up to" from WordPress.org readme
+        id: extract-wporg-tested-up-to
+        run: |
+          WPORG_TESTED_UP_TO=$(grep -E "^Tested up to:" /tmp/wp-org-readme.txt | awk -F ': +' '{print $2}')
+          if [ -z "$WPORG_TESTED_UP_TO" ]; then
+            echo "::error::Unable to parse Tested up to version from wp.org readme.txt"
+            exit 1
+          fi
+          echo "version=$WPORG_TESTED_UP_TO" >> "$GITHUB_OUTPUT"
+
+      - name: Compare versions and skip if not strictly greater
+        id: compare-versions
+        run: |
+          LOCAL="${{ steps.extract-tested-up-to.outputs.version }}"
+          WPORG="${{ steps.extract-wporg-tested-up-to.outputs.version }}"
+
+          # Determine the maximum of the two versions.
+          MAX_VERSION="$(printf '%s\n%s\n' "$WPORG" "$LOCAL" | sort -V | tail -n1)"
+
+          # Only deploy if LOCAL is the max and different from WPORG (i.e., LOCAL > WPORG).
+          if [[ "$MAX_VERSION" == "$LOCAL" && "$LOCAL" != "$WPORG" ]]; then
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No update needed. Local ($LOCAL) is not greater than wp.org ($WPORG)."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare and update readme.txt
+        if: steps.compare-versions.outputs.should_deploy == 'true'
+        env:
+          LOCAL_TESTED_UP_TO: ${{ steps.extract-tested-up-to.outputs.version }}
+        run: |
+          # Replace local readme.txt with WordPress.org version, updating only the "Tested up to" line.
+          cp /tmp/wp-org-readme.txt "./readme.txt"
+          sed -i -E 's/^(Tested up to:[[:space:]]*).+/\1'"$LOCAL_TESTED_UP_TO"'/' "./readme.txt"
+          # Show the diff of what's being updated.
+          echo "Changes made to readme.txt:"
+          diff -u /tmp/wp-org-readme.txt "./readme.txt" || true
+
+      - name: Deploy readme.txt to WordPress.org
+        if: steps.compare-versions.outputs.should_deploy == 'true'
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: ${{ env.SLUG }}
+          SKIP_ASSETS: true
+          IGNORE_OTHER_FILES: true

--- a/.github/workflows/wordpress-org-deploy.yml
+++ b/.github/workflows/wordpress-org-deploy.yml
@@ -1,0 +1,93 @@
+name: Deploy to WordPress.org
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to deploy (e.g. 1.5.0)'
+        required: true
+        type: string
+
+jobs:
+  check-user:
+    name: Check User Authorization
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check if user is authorized
+        shell: bash
+        run: |
+          ALLOWED_USERS=("dimitris-am" "cheh")
+          CURRENT_USER="${{ github.actor }}"
+          AUTHORIZED=false
+
+          for user in "${ALLOWED_USERS[@]}"; do
+            if [[ "$user" == "$CURRENT_USER" ]]; then
+              AUTHORIZED=true
+              break
+            fi
+          done
+
+          if [[ "$AUTHORIZED" != "true" ]]; then
+            echo "Error: User $CURRENT_USER is not authorized to run this workflow"
+            exit 1
+          fi
+
+  deploy:
+    name: Deploy File Upload Types to WordPress.org
+    runs-on: ubuntu-24.04
+    needs: check-user
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.19.1'
+
+      - run: npm install -g npm@10.9.2
+
+      - name: Install PHP 7.4 and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository ppa:ondrej/php -y
+          sudo apt-get update
+          sudo apt-get install -y php7.4 php7.4-cli php7.4-curl php7.4-zip php7.4-mbstring php7.4-xml php7.4-mysql unzip
+          php -v
+
+      - name: Install Composer
+        run: |
+          php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+          php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); exit(1); }"
+          php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+          php -r "unlink('composer-setup.php');"
+          composer --version
+
+      - name: Install WP-CLI
+        run: |
+          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          chmod +x wp-cli.phar
+          sudo mv wp-cli.phar /usr/local/bin/wp
+          wp --info
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build plugin
+        run: |
+          npm run gulp build
+          cd build
+          unzip file-upload-types-*.zip
+          rm -rf file-upload-types-*.zip
+
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: file-upload-types
+          VERSION: ${{ inputs.version }}
+          BUILD_DIR: build/file-upload-types/


### PR DESCRIPTION
## Summary

Ports the two release-automation GitHub Actions we use on WPForms into this repo, adapted for file-upload-types' single-plugin (repo-root) layout and Gulp build.

- **`wordpress-org-deploy.yml`** — manual (`workflow_dispatch`, takes a `version` input). Installs Node/PHP/Composer/WP-CLI, runs `npm run gulp build`, unzips `build/file-upload-types-*.zip`, and deploys `build/file-upload-types/` to the wordpress.org SVN repo via `10up/action-wordpress-plugin-deploy`.
- **`wordpress-org-bump-tested-up-to.yml`** — manual. Pushes *only* an updated `readme.txt` "Tested up to" header to wp.org trunk when the repo's local value is strictly higher than what's live, via `10up/action-wordpress-plugin-asset-update` (`SKIP_ASSETS` + `IGNORE_OTHER_FILES`, so nothing else is touched).

Both jobs are gated by a hardcoded GitHub-username allowlist (`check-user` job).

## Key adaptations from the WPForms originals
- Paths drop the `wpforms/` monorepo prefix — build runs at repo root.
- `SLUG: file-upload-types`, `BUILD_DIR: build/file-upload-types/`.
- `ASSETS_DIR` omitted (no `assets/wporg/` or `.wordpress-org/` dir exists yet).
- Slack notification step removed.
- Fixed the allowlist comma bug (`"andreas-am",` → `"andreas-am"`).
- Bump workflow is **live** (deploy step enabled, not the WPForms test-mode stub).
- Minor shellcheck cleanup (`if ! curl …` instead of dead `$?` check; quoted `$GITHUB_OUTPUT`). Both files pass `actionlint` clean.

## Before these can run ⚠️
1. **Add repo secrets** `SVN_USERNAME` and `SVN_PASSWORD` (a wordpress.org account; Settings → Secrets and variables → Actions).
2. That account must be a **Committer** on the `file-upload-types` wordpress.org plugin, or SVN will reject the push.
3. `workflow_dispatch` only shows the "Run workflow" button once these files are on the **default branch (`develop`)** — i.e. after this PR merges.
4. Before deploying, make sure `Version:` (`file-upload-types.php`), `Stable tag:` (`readme.txt`), and `version` (`package.json`, used for the build zip name) all match the version you input.

## Test plan
- `actionlint` passes on both files (run locally).
- Safe first run after merge: the bump workflow with local `Tested up to: 7.0` == wp.org should report "No update needed" and push nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)